### PR TITLE
fix(ConfigChecker): Invalid port or host

### DIFF
--- a/include/ConfigChecker.hpp
+++ b/include/ConfigChecker.hpp
@@ -2,10 +2,16 @@
 
 #include <cstring>
 #include <fstream>
+#include <netdb.h>
 #include <set>
 #include <sstream>
 #include <string>
+#include <sys/socket.h>
+#include <sys/types.h>
 #include <vector>
+
+#include "Exception.hpp"
+#include "Utils.hpp"
 
 class ConfigChecker
 {
@@ -26,6 +32,7 @@ class ConfigChecker
 		static bool validateErrorCode(const std::string &code);
 		static bool validateErrorPages(const std::string &errorPages);
 		static bool validateHttpStatusCode(const std::string &code);
+		static bool validateServerName(const std::string &serverName);
 
 		// Methods
 		void validateConfigFile();

--- a/tests/ConfigChecker.test.cpp
+++ b/tests/ConfigChecker.test.cpp
@@ -52,6 +52,23 @@ TEST_CASE("validateHostname", "[ConfigChecker]")
 	REQUIRE(ConfigChecker::validateHostname("www.google.com.") == false);
 	REQUIRE(ConfigChecker::validateHostname("ho$tn@me-with-inv@lid-ch@r@cter$") == false);
 	REQUIRE(ConfigChecker::validateHostname(std::string(64, 'A').append(".com")) == false);
+	REQUIRE(ConfigChecker::validateHostname("unknow") == false);
+}
+
+TEST_CASE("validateServerName", "[ConfigChecker]")
+{
+	// Valid testcases
+	REQUIRE(ConfigChecker::validateServerName("localhost") == true);
+	REQUIRE(ConfigChecker::validateServerName("www.google.com") == true);
+
+	// Invalid testcases
+	REQUIRE(ConfigChecker::validateServerName("") == false);
+	REQUIRE(ConfigChecker::validateServerName(std::string(255, 'A')) == false);
+	REQUIRE(ConfigChecker::validateServerName("-thisShouldBeInvalid") == false);
+	REQUIRE(ConfigChecker::validateServerName("thisAlsoShouldBeInvalid-") == false);
+	REQUIRE(ConfigChecker::validateServerName("www.google.com.") == false);
+	REQUIRE(ConfigChecker::validateServerName("ho$tn@me-with-inv@lid-ch@r@cter$") == false);
+	REQUIRE(ConfigChecker::validateServerName(std::string(64, 'A').append(".com")) == false);
 }
 
 TEST_CASE("validateSize", "[ConfigChecker]")
@@ -380,6 +397,32 @@ TEST_CASE("validateErrorPagesDirective", "[ConfigChecker]")
 			 << "\tautoindex on" << std::endl
 			 << "\tupload off" << std::endl
 			 << "\t}" << std::endl
+			 << "}" << std::endl;
+
+		file.close();
+		REQUIRE_THROWS(ConfigChecker("test.conf"));
+		remove("test.conf");
+	}
+	// Wrong testcase #9 (Invalid hostname on listen)
+	{
+		std::fstream file("test.conf", std::ios::out | std::ios::trunc);
+
+		file << "server {" << std::endl
+			 << "\tlisten not-localhost:8080" << std::endl
+			 << "\tserver_name webserv" << std::endl
+			 << "}" << std::endl;
+
+		file.close();
+		REQUIRE_THROWS(ConfigChecker("test.conf"));
+		remove("test.conf");
+	}
+	// Wrong testcase #10 (Invalid port number on listen)
+	{
+		std::fstream file("test.conf", std::ios::out | std::ios::trunc);
+
+		file << "server {" << std::endl
+			 << "\tlisten localhost:80800" << std::endl
+			 << "\tserver_name webserv" << std::endl
 			 << "}" << std::endl;
 
 		file.close();


### PR DESCRIPTION
Fix checking on invalid port number and hosts
Add validateServerName for `server_name` directive
Add appropriate tests